### PR TITLE
A new feature for token-usage option added

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,6 +54,7 @@ So if you do not want to write node server.js everytime you run, instead using v
   - -T, --temperature <number> : Set the temperature parameter for the model (Groq) (default: 0.2).
   - -o, --output <file> : Specify an output file to save the results.
   - -h, --help : Display help for VShell commands.
+  - -t, --token-usage : Speicfy specify the usage of token for prompt and response
 
 # Example
 To process README.md with a custom temperature setting and save the result to output.txt, use:

--- a/ai_config/grogConfig.js
+++ b/ai_config/grogConfig.js
@@ -27,8 +27,15 @@ async function promptGroq(prompt, temperature = 0.5) {
 
     // Response from Groq
     const response = chatCompletion.choices[0]?.message?.content || "";
+    
+    // Retrieve Token Usage from Response
+    const promptToken = chatCompletion.usage.prompt_tokens;
+    const completionToken = chatCompletion.usage.completion_tokens;
+    const totalToken = chatCompletion.usage.total_tokens
+    const tokenInfo = {promptToken, completionToken, totalToken};
 
-    return { response };
+
+    return { response, tokenInfo };
   } catch (error) {
     process.stderr.write(`Error: Error processing data with Groq: ${err}. \n`);
   }

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,6 +12,9 @@
         "commander": "^12.1.0",
         "dotenv": "^16.4.5",
         "groq-sdk": "^0.7.0"
+      },
+      "bin": {
+        "vshell": "src/server.js"
       }
     },
     "node_modules/@types/node": {

--- a/src/ai.js
+++ b/src/ai.js
@@ -13,7 +13,16 @@ async function promptAI(prompt, temperature, options) {
   }
   process.stderr.write(`Info: Prompting AI with temperature: ${temperature}\n`);
   try {
-    const { response } = await initializeModel(prompt, temperature);
+    const { response, tokenInfo } = await initializeModel(prompt, temperature);
+
+    console.log("*******************")
+    console.log(options);
+    console.log("*******************")
+  
+    console.log("==================")
+    console.log(tokenInfo);
+    console.log("==================")
+    
 
     // Handle output
     if (options.outputFile) {

--- a/src/server.js
+++ b/src/server.js
@@ -21,6 +21,7 @@ program
   .option("-d, --debug", "output extra debugging")
   .option("-u, --update", "update to the latest version")
   .option("-m, --model", "specify the model to use")
+  .option("-t, --token-usage", "specify the usage of token for prompt and response") 
   .option(
     "-T, --temperature <number>",
     "set the temperature for the model (Groq)",
@@ -29,6 +30,7 @@ program
       ? parseFloat(process.env.GROQ_TEMPERATURE)
       : 0.7
   );
+  
 
 // Define a command to handle file inputs
 program


### PR DESCRIPTION
This pull request solves the `issue #6` in your repo.

- A new feature for token-usage option has been added.

`grogConfig.js`, `ai.js`, `server.js`, `README.md` has been modified.
- The tool can get a new option flag for `-t`, `--token-usage`
- When The tool is run with the flag, it will print out the token usage in the stdout




